### PR TITLE
Compile failed with clang++ on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ list(GET PROJECT_VERSION_PARTS 1 PROJECT_VERSION_MINOR)
 list(GET PROJECT_VERSION_PARTS 2 PROJECT_VERSION_PATCH)
 set(PROJECT_SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 
+set(CMAKE_MACOSX_RPATH 1)
+
 #------------------------------------------------------
 # Build type
 #------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,9 @@ set(EXTRA_EXE_LINKER_FLAGS "")
 set(EXTRA_EXE_LINKER_FLAGS_RELEASE "")
 set(EXTRA_EXE_LINKER_FLAGS_DEBUG "")
 
-IF(CMAKE_COMPILER_IS_GNUCXX OR MINGW)
+IF(CMAKE_CXX_COMPILER_ID MATCHES "GNU"
+   OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+   OR MINGW)
     set(ENABLE_PROFILING 		OFF CACHE BOOL "Enable profiling in the GCC compiler (Add flags: -g -pg)")
     set(USE_OMIT_FRAME_POINTER 	ON CACHE BOOL "Enable -fomit-frame-pointer for GCC")
     if(${CMAKE_SYSTEM_PROCESSOR} MATCHES arm*) # We can use only -O2 because the -O3 causes gcc crash

--- a/src/vocabulary_creator.cpp
+++ b/src/vocabulary_creator.cpp
@@ -1,6 +1,8 @@
 #include "vocabulary_creator.h"
+#ifdef _OPENMP
 #ifndef __ANDROID__
 #include <omp.h>
+#endif
 #else
 inline int omp_get_max_threads(){return 1;}
 inline int omp_get_thread_num(){return 0;}


### PR DESCRIPTION
Compile of FBoW was failed with clang++ on macOS (10.13).
I have confirmed that `make` operation terminated with an error with the following versions of compilers:

```bash
clang version 7.0.0 (tags/RELEASE_700/final)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /usr/local/opt/llvm/bin
```
```bash
Apple LLVM version 9.1.0 (clang-902.0.39.2)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

To tackle with these issues, I have added/fixed these components:

- Check `_OPENMP` flag is defined or not when including `omp.h`
- Deal with clang compiler in `CMakeLists.txt`
- Use rpaths on macOS to suppress warnings

Thank you for your consideration.