### PR TITLE
fixed segfault due to double delete

### DIFF
--- a/src/vocabulary_creator.cpp
+++ b/src/vocabulary_creator.cpp
@@ -29,8 +29,9 @@ void VocabularyCreator::create(fbow::Vocabulary &Voc, const std::vector<cv::Mat>
     if(!(_descType==CV_8UC1|| _descType==CV_32FC1))
         throw std::runtime_error("Descriptors must be binary CV_8UC1 or float  CV_32FC1");
     if (_descType==CV_8UC1){
-//        if (_descNBytes==32)dist_func=distance_hamming_32bytes;
-//        else
+        if (_descNBytes==32)
+            dist_func=distance_hamming_32bytes;
+        else
             dist_func=distance_hamming_generic;
     }
     else  dist_func=distance_float_generic;


### PR DESCRIPTION
...when copy-constructing fbow::Vocabulary (disregarded Rule of Three)

My application crashed in a method where I returned a generated vocabulary from a method. Apparently the default copy ctor simply copies the char pointer which got deleted twice (once in the dtor of the local vocabulary object, a second time by the returned copy). I replaced the raw pointer with a unique_ptr with a custom deleter and made the object move-only so it can be returned from methods.

reenabled distance_hamming_32bytes.

Any reason why the latter was commented out? Gives a 4x speedup for me on Win10, i7