### PR TITLE
improved const-correctness

### DIFF
--- a/src/fbow.cpp
+++ b/src/fbow.cpp
@@ -48,7 +48,7 @@ void Vocabulary::setParams(int aligment, int k, int desc_type, int desc_size, in
 
 }
 
-void Vocabulary::transform(const cv::Mat &features, int level,fBow &result,fBow2&result2){
+void Vocabulary::transform(const cv::Mat &features, int level,fBow &result,fBow2&result2) const {
     if (features.rows==0) throw std::runtime_error("Vocabulary::transform No input data");
     if (features.type()!=_params._desc_type) throw std::runtime_error("Vocabulary::transform features are of different type than vocabulary");
     if (features.cols *  features.elemSize() !=size_t(_params._desc_size)) throw std::runtime_error("Vocabulary::transform features are of different size than the vocabulary ones");
@@ -89,7 +89,7 @@ void Vocabulary::transform(const cv::Mat &features, int level,fBow &result,fBow2
 
 }
 
-fBow Vocabulary::transform(const cv::Mat &features)
+fBow Vocabulary::transform(const cv::Mat &features) const
 {
     if (features.rows==0) throw std::runtime_error("Vocabulary::transform No input data");
     if (features.type()!=_params._desc_type) throw std::runtime_error("Vocabulary::transform features are of different type than vocabulary");

--- a/src/fbow.h
+++ b/src/fbow.h
@@ -203,8 +203,8 @@ private:
         inline void getFeature(int i,cv::Mat  feature) const
           { memcpy(feature.ptr<char>(0), _blockstart + _feature_off_start + i * _desc_size_bytes, _desc_size_bytes); }
 
-        template<typename T> inline conditional_const<T>*getFeature(int i)
-          { return (conditional_const<T>*)(_blockstart + _feature_off_start + i * _desc_size_bytes_wp); }
+        template<typename TT> inline conditional_const<TT>*getFeature(int i)
+          { return (conditional_const<TT>*)(_blockstart + _feature_off_start + i * _desc_size_bytes_wp); }
         
         T* _blockstart;
         uint64_t _desc_size_bytes=0;//size of the descriptor(without padding)

--- a/src/vocabulary_creator.h
+++ b/src/vocabulary_creator.h
@@ -82,6 +82,7 @@ private:
     void createLevel(const std::vector<uint32_t> &findices,  int parent=0, int curL=0);
     void createLevel(int parent=0, int curL=0, bool recursive=true);
     std::vector<uint32_t> getInitialClusterCenters(const std::vector<uint32_t> &findices);
+    std::vector<uint32_t> initialClusterCentersKmpp(const std::vector<uint32_t> &findices);
 
     std::size_t vhash(const std::vector<std::vector<uint32_t> >& v_vec)  ;
 
@@ -148,7 +149,6 @@ private:
     struct Node{
         Node(){}
         Node(uint32_t Id,uint32_t Parent,const cv::Mat &Feature, uint32_t Feat_idx=std::numeric_limits<uint32_t>::max() ):id(Id),parent(Parent),feature(Feature),feat_idx(Feat_idx){
-
         }
 
         uint32_t id=std::numeric_limits<uint32_t>::max();//id of this node in the tree


### PR DESCRIPTION
I tried to improve the (logical) const-correctness of the library as methods such as Vocabulary::transform don't modify any internal data from the library user's perspective(*). Since it's not const-qualified however, it enforces its non-constness on user methods which then snowballs further from there and has potential to makes code somewhat unclean.

I therefore templated the internal Block structure on a type that's either char or const char (could further be enforced via type traits) and then conditionally const-qualified all accesses to the internal block structure depending on whether or not the type itself was templated on a const type on construction (which is enforced in const methods, see below).

This results in this being valid:

```
void MyClass::foo()
{
  Block<char> block=getBlock(0);
  block.setLeaf(true);
  block.nonConstMethod();
  block.constMethod();
}

void MyClass::foo() const
{
  Block<const char> block=getBlock(0);
  bool is_leaf = block.isLeaf();
  block.constMethod();
}
```

while any of these don't compile

```
void MyClass::foo() const
{
  Block<char> block = getBlock(0);  // error: getBlock returns Block<const char>
  Block<const char> block=getBlock(0);  // ok
  block.setLeaf(true);  // error: can't modify through const object
  block.nonConstMethod();  // same

  auto* binfo = block.getBlockNodeInfo(0);
  binfo->nonConstMethod();  // error: constness is also forwarded to BlockNodeInfo
}
```

C++17 can even automatically deduce Block's template type from the ctor argument but since I'm not sure what the requirements for the library are, I didn't rely on this. Can you please tell me which platforms and/or language standard you are offering to support so I can make sure it compiles for these as well?

(*) The one exception to this rule is the cpu_info but since this is an implementation detail that imo should be transparent to the user and not affect (logical) constness of the API interface, I qualified it as mutable.